### PR TITLE
🎨 Create Reusable Project Item Component 

### DIFF
--- a/apps/elewa-website/src/environments/environment.prod.ts.example
+++ b/apps/elewa-website/src/environments/environment.prod.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: true,
-};

--- a/apps/elewa-website/src/environments/environment.ts.example
+++ b/apps/elewa-website/src/environments/environment.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: false,
-};

--- a/libs/data/sections/highlighted-projects.data.ts
+++ b/libs/data/sections/highlighted-projects.data.ts
@@ -1,0 +1,29 @@
+import { ProjectItem } from '../../models/sections/projects/project-item.interface';
+
+/* Add sample data to be used by the cards*/
+
+export const __highlightedProjects: ProjectItem[] = [
+  {
+    title: 'Introducing Conversational lerning ipsum dolar',
+    description:
+      'Eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam dolorem ipsum quia',
+    tag: 'Education',
+    imgSrc:
+      'https://img.freepik.com/free-photo/happy-family-silhouette-sunset_1303-22466.jpg?w=740&t=st=1691417747~exp=1691418347~hmac=22598c9578711ae29543ec33dce4d2933a0b720b8a0389610e2f41f8cc032bc9',
+  },
+  {
+    title: 'Project 2',
+    description: 'Description of Project 2',
+    tag: 'Medicine',
+    imgSrc: 'https://images.unsplash.com/photo-1526256262350-7da7584cf5eb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Nnx8bWVkaWNhbHxlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=500&q=60',
+  },
+  {
+    title: 'Cardio',
+    description:
+      'Run Barry, Run',
+    tag: 'Sport',
+    imgSrc:
+      'https://images.unsplash.com/photo-1461896836934-ffe607ba8211?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8U3BvcnR8ZW58MHx8MHx8fDA%3D&auto=format&fit=crop&w=500&q=60',
+  },
+  // Add more data as needed
+];

--- a/libs/elements/cards/.eslintrc.json
+++ b/libs/elements/cards/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/elements/cards/README.md
+++ b/libs/elements/cards/README.md
@@ -1,0 +1,7 @@
+# elements-cards
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test elements-cards` to execute the unit tests.

--- a/libs/elements/cards/jest.config.ts
+++ b/libs/elements/cards/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'elements-cards',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../coverage/libs/elements/cards',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/elements/cards/project.json
+++ b/libs/elements/cards/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "elements-cards",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/elements/cards/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/elements/cards/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/elements/cards/**/*.ts",
+          "libs/elements/cards/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/elements/cards/src/index.ts
+++ b/libs/elements/cards/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/elements-cards.module';

--- a/libs/elements/cards/src/lib/elements-cards.module.ts
+++ b/libs/elements/cards/src/lib/elements-cards.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ElewaProjectItemCardComponent } from './elewa-project-item-card/elewa-project-item-card.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ElewaProjectItemCardComponent],
+})
+export class ElementsCardsModule {}

--- a/libs/elements/cards/src/lib/elements-cards.module.ts
+++ b/libs/elements/cards/src/lib/elements-cards.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { ElewaProjectItemCardComponent } from './elewa-project-item-card/elewa-project-item-card.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, NgOptimizedImage],
   declarations: [ElewaProjectItemCardComponent],
   exports: [ElewaProjectItemCardComponent]
 })

--- a/libs/elements/cards/src/lib/elements-cards.module.ts
+++ b/libs/elements/cards/src/lib/elements-cards.module.ts
@@ -5,5 +5,6 @@ import { ElewaProjectItemCardComponent } from './elewa-project-item-card/elewa-p
 @NgModule({
   imports: [CommonModule],
   declarations: [ElewaProjectItemCardComponent],
+  exports: [ElewaProjectItemCardComponent]
 })
 export class ElementsCardsModule {}

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
@@ -1,0 +1,1 @@
+<p>elewa-project-item-card works!</p>

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
@@ -1,1 +1,19 @@
-<p>elewa-project-item-card works!</p>
+<div class="card">
+  <div class="card-image">
+    <img
+      [src]="project.imgSrc"
+      ngSrcset="100w, 200w, 300w"
+      sizes="(max-width: 480px) 100vw,
+        (max-width: 768px) 50vw,
+        33.3vw"
+      alt="{{ project.title }}"
+    />
+  </div>
+  <div class="card-tag">
+    <p class="card-tag-info">{{ project.tag }}</p>
+  </div>
+  <p class="card-title">{{ project.title }}</p>
+  <p class="card-description">
+    {{ project.title }}
+  </p>
+</div>

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.html
@@ -1,19 +1,21 @@
-<div class="card">
-  <div class="card-image">
-    <img
-      [src]="project.imgSrc"
-      ngSrcset="100w, 200w, 300w"
-      sizes="(max-width: 480px) 100vw,
+<div class="card-container">
+  <div class="card" *ngFor="let project of highlightedProjects">
+    <div class="card-image">
+      <img
+        [src]="project.imgSrc"
+        ngSrcset="100w, 200w, 300w"
+        sizes="(max-width: 480px) 100vw,
         (max-width: 768px) 50vw,
         33.3vw"
-      alt="{{ project.title }}"
-    />
+        alt="{{ project.title }}"
+      />
+    </div>
+    <div class="card-tag">
+      <p class="card-tag-info">{{ project.tag }}</p>
+    </div>
+    <p class="card-title">{{ project.title }}</p>
+    <p class="card-description">
+      {{ project.description }}
+    </p>
   </div>
-  <div class="card-tag">
-    <p class="card-tag-info">{{ project.tag }}</p>
-  </div>
-  <p class="card-title">{{ project.title }}</p>
-  <p class="card-description">
-    {{ project.title }}
-  </p>
 </div>

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
@@ -9,10 +9,10 @@
   max-width: 271px;
   height: auto;
   box-sizing: border-box;
-  background-color: rgba(255, 255, 255, 1);
+  background-color: var(--card-background-color);
   display: flex;
   font-family: Inter;
-  color: rgba(0, 0, 0, 1);
+  color: var(--card-color);
   text-align: left;
   font-weight: 400;
   gap: 15px;
@@ -21,7 +21,7 @@
   padding-left: 11px;
   padding-right: 11px;
   padding-top: 11px;
-  font: 'DM Sans', sans-serif;
+  font-style: var(--card-font-style);
 
   @media (min-width: 768px) {
     max-width: 100%; /* Allow the card to take up full width on tablets and larger screens */

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
@@ -1,3 +1,9 @@
+.card-container {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+
 .card {
   width: 100%;
   max-width: 271px;

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
@@ -1,7 +1,7 @@
 .card-container {
-    display: inline-flex;
+    display: flex;
     flex-wrap: wrap;
-    gap: 20px;
+    gap: 15px;
 }
 
 .card {
@@ -22,11 +22,6 @@
   padding-right: 11px;
   padding-top: 11px;
   font-style: var(--card-font-style);
-
-  @media (min-width: 768px) {
-    max-width: 100%; /* Allow the card to take up full width on tablets and larger screens */
-    // flex-direction: row; /* Change to a horizontal layout on tablets and larger screens */
-  }
 }
 
 .card-image {

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.scss
@@ -1,0 +1,94 @@
+.card {
+  width: 100%;
+  max-width: 271px;
+  height: auto;
+  box-sizing: border-box;
+  background-color: rgba(255, 255, 255, 1);
+  display: flex;
+  font-family: Inter;
+  color: rgba(0, 0, 0, 1);
+  text-align: left;
+  font-weight: 400;
+  gap: 15px;
+  flex-direction: column;
+  padding-bottom: 18px;
+  padding-left: 11px;
+  padding-right: 11px;
+  padding-top: 11px;
+  font: 'DM Sans', sans-serif;
+
+  @media (min-width: 768px) {
+    max-width: 100%; /* Allow the card to take up full width on tablets and larger screens */
+    // flex-direction: row; /* Change to a horizontal layout on tablets and larger screens */
+  }
+}
+
+.card-image {
+  border-radius: 12px;
+  height: auto;
+  background-size: cover;
+  background-position: center;
+  // background-image: url(https://uortjlczjmucmpaqqhqm.supabase.co/storage/v1/object/public/firejet-converted-images/images/eae313a48883a46e7a2a60ee806e73a8052191be.webp);
+  box-sizing: border-box;
+  flex-grow: 1;
+  width: 100%;
+  @media (min-width: 768px) {
+    width: 50%; /* Take up half the width on tablets and larger screens */
+    height: 317px; /* Restore the fixed height for consistent appearance */
+  }
+}
+
+.card-image img {
+  border-radius: 12px;
+  height: 317px;
+  background-size: cover;
+  background-position: center;
+  box-sizing: border-box;
+  flex-grow: 1;
+  width: 248px;
+}
+
+.card-tag {
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  // box-shadow-width:1px;
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+  box-shadow: 0px 0px 0px 1px rgba(184, 178, 178, 1) inset;
+  background-color: rgba(255, 255, 255, 1);
+  padding-right: 12px;
+  padding-left: 12px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  box-sizing: border-box;
+  height: 18px;
+  width: 62px;
+  margin-top: 8px;
+  margin-bottom: -14px;
+
+  @media (min-width: 768px) {
+    margin-top: 0; /* Remove the margin on tablets and larger screens */
+  }
+}
+
+.card-tag-info {
+  width: 38px;
+  height: 10px;
+  font-size: 8px;
+}
+
+.card-title {
+  font-size: 18px;
+  width: 248px;
+  height: 10px;
+  margin-top: 12px;
+}
+
+.card-description {
+  font-size: 11px;
+  width: 246px;
+  height: 27px;
+  margin-top: 40px;
+  //   padding-bottom: 20px;
+}

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.spec.ts
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaProjectItemCardComponent } from './elewa-project-item-card.component';
+
+describe('ElewaProjectItemCardComponent', () => {
+  let component: ElewaProjectItemCardComponent;
+  let fixture: ComponentFixture<ElewaProjectItemCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaProjectItemCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaProjectItemCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-project-item-card',
+  templateUrl: './elewa-project-item-card.component.html',
+  styleUrls: ['./elewa-project-item-card.component.scss'],
+})
+export class ElewaProjectItemCardComponent {}

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { ProjectItem } from 'libs/models/sections/projects/project-item.interface';
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { __highlightedProjects } from 'libs/data/sections/highlighted-projects.data'
 
 @Component({

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ProjectItem } from 'libs/models/sections/projects/project-item.interface';
-import { NgOptimizedImage } from '@angular/common';
+import { __highlightedProjects } from 'libs/data/sections/highlighted-projects.data'
 
 @Component({
   selector: 'elewa-website-elewa-project-item-card',
@@ -10,13 +10,15 @@ import { NgOptimizedImage } from '@angular/common';
 
 /* A card that displays an image and its description based on
 the values passed to the card. The card should be reusable */
-
 export class ElewaProjectItemCardComponent {
   /** Card info to be passed in */
   @Input() project: ProjectItem = {
-    title: 'Introducing Conversational lerning ipsum dolar',
-    description: 'Eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam dolorem ipsum quia',
-    tag: 'Education',
-    imgSrc: 'https://img.freepik.com/free-photo/happy-family-silhouette-sunset_1303-22466.jpg?w=740&t=st=1691417747~exp=1691418347~hmac=22598c9578711ae29543ec33dce4d2933a0b720b8a0389610e2f41f8cc032bc9',
+    title: '',
+    description: '',
+    tag: '',
+    imgSrc: ''
   };
+
+  // incorporate the mock projects data
+  highlightedProjects: ProjectItem[] = __highlightedProjects;
 }

--- a/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-project-item-card/elewa-project-item-card.component.ts
@@ -1,8 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { ProjectItem } from 'libs/models/sections/projects/project-item.interface';
+import { NgOptimizedImage } from '@angular/common';
 
 @Component({
   selector: 'elewa-website-elewa-project-item-card',
   templateUrl: './elewa-project-item-card.component.html',
   styleUrls: ['./elewa-project-item-card.component.scss'],
 })
-export class ElewaProjectItemCardComponent {}
+
+/* A card that displays an image and its description based on
+the values passed to the card. The card should be reusable */
+
+export class ElewaProjectItemCardComponent {
+  /** Card info to be passed in */
+  @Input() project: ProjectItem = {
+    title: 'Introducing Conversational lerning ipsum dolar',
+    description: 'Eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam dolorem ipsum quia',
+    tag: 'Education',
+    imgSrc: 'https://img.freepik.com/free-photo/happy-family-silhouette-sunset_1303-22466.jpg?w=740&t=st=1691417747~exp=1691418347~hmac=22598c9578711ae29543ec33dce4d2933a0b720b8a0389610e2f41f8cc032bc9',
+  };
+}

--- a/libs/elements/cards/src/test-setup.ts
+++ b/libs/elements/cards/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/elements/cards/tsconfig.json
+++ b/libs/elements/cards/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/elements/cards/tsconfig.lib.json
+++ b/libs/elements/cards/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/elements/cards/tsconfig.spec.json
+++ b/libs/elements/cards/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/elements/theming/_variables.scss
+++ b/libs/elements/theming/_variables.scss
@@ -4,4 +4,9 @@
 :root {
   /** primary colors **/
   --elewa-website-color-primary-black: #000;
+
+  /** card CSS variables **/
+  --card-font-style: 'DMSans-Regular';
+  --card-background-color: rgba(255, 255, 255, 1);
+  --card-color: rgba(0, 0, 0, 1)
 }

--- a/libs/features/pages/home/src/lib/features-pages-home.module.ts
+++ b/libs/features/pages/home/src/lib/features-pages-home.module.ts
@@ -5,8 +5,10 @@ import { HomePageComponent } from './main/home/home-page.component';
 
 import { HomeRoutingModule } from './home.routing';
 
+import { ElementsCardsModule } from '@elewa-website/elements/cards';
+
 @NgModule({
-  imports: [CommonModule, HomeRoutingModule],
+  imports: [CommonModule, HomeRoutingModule, ElementsCardsModule],
   declarations: [HomePageComponent],
   exports: [HomePageComponent],
 })

--- a/libs/features/pages/home/src/lib/main/home/home-page.component.html
+++ b/libs/features/pages/home/src/lib/main/home/home-page.component.html
@@ -1,3 +1,4 @@
 <div class="home-page">
   Elewa Education
 </div>
+<elewa-website-elewa-project-item-card></elewa-website-elewa-project-item-card>

--- a/libs/models/sections/projects/.eslintrc.json
+++ b/libs/models/sections/projects/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/models/sections/projects/README.md
+++ b/libs/models/sections/projects/README.md
@@ -1,0 +1,7 @@
+# models-sections-projects
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test models-sections-projects` to execute the unit tests.

--- a/libs/models/sections/projects/jest.config.ts
+++ b/libs/models/sections/projects/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'models-sections-projects',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/models/sections/projects',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/models/sections/projects/project-item.interface.ts
+++ b/libs/models/sections/projects/project-item.interface.ts
@@ -1,0 +1,6 @@
+export interface ProjectItem {
+  title: string;
+  description: string;
+  tag: string;
+  imgSrc: string;
+}

--- a/libs/models/sections/projects/project.json
+++ b/libs/models/sections/projects/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "models-sections-projects",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/models/sections/projects/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/models/sections/projects/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/models/sections/projects/**/*.ts",
+          "libs/models/sections/projects/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/models/sections/projects/src/index.ts
+++ b/libs/models/sections/projects/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/models-sections-projects.module';

--- a/libs/models/sections/projects/src/lib/models-sections-projects.module.ts
+++ b/libs/models/sections/projects/src/lib/models-sections-projects.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class ModelsSectionsProjectsModule {}

--- a/libs/models/sections/projects/src/test-setup.ts
+++ b/libs/models/sections/projects/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/models/sections/projects/tsconfig.json
+++ b/libs/models/sections/projects/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/models/sections/projects/tsconfig.lib.json
+++ b/libs/models/sections/projects/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/models/sections/projects/tsconfig.spec.json
+++ b/libs/models/sections/projects/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@elewa-website/elements/cards": ["libs/elements/cards/src/index.ts"],
       "@elewa-website/features/pages/about": [
         "libs/features/pages/about/src/index.ts"
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,9 @@
         "libs/features/pages/home/src/index.ts"
       ],
       "@elewa-website/models/data/ui": ["libs/models/data/ui/src/index.ts"],
+      "@elewa-website/models/sections/projects": [
+        "libs/models/sections/projects/src/index.ts"
+      ],
       "@elewa-website/models/ui/images": ["libs/models/ui/images/src/index.ts"]
     }
   },


### PR DESCRIPTION
# Description

The goal is to create a reusable Angular component named elewa-project-item-card for displaying project items in a carousel across the website. The component will adhere to the provided design specifications and support responsive behavior. This will enhance the user experience by presenting project information in an organized and visually appealing manner.
The NgOptimizedImage dependency is added to integrate srcsets to the image rendering of the card.

Fixes #14 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot (optional)
![Screenshot 2023-08-08 180128](https://github.com/italanta/elewa-website/assets/84719074/8cc60f72-341c-469a-ac9e-84537fcff2ce)

## How Has This Been Tested?

- [x] Test A - A visual comparison was conducted between the card and the one presented in the GitHub issue.
- [x] Test B - A test was conducted by adding new data entries to the `highlighted-projects.data.ts` file to verify the proper formation of new cards.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
