### PR TITLE
Reusable news item component #11

### DIFF
--- a/apps/elewa-website/src/app/app.module.ts
+++ b/apps/elewa-website/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { AppComponent } from './app.component';
 import { TranslocoRootModule } from './transloco-root.module';
 import { AppHeaderModule } from '@elewa-website/elements/layout/header';
+import { CardsModule } from '@elewa-website/elements/cards';
 
 import { AppRoutingModule } from './app.routing';
 
@@ -16,6 +17,7 @@ import { AppRoutingModule } from './app.routing';
     HttpClientModule,
     TranslocoRootModule,
     AppHeaderModule,
+    CardsModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/libs/data/ui/content-text/src/index.ts
+++ b/libs/data/ui/content-text/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/mock-content-text.data';
+export * from './lib/highlighted-news.data'

--- a/libs/data/ui/content-text/src/lib/highlighted-news.data.ts
+++ b/libs/data/ui/content-text/src/lib/highlighted-news.data.ts
@@ -1,0 +1,24 @@
+import { NewsItem } from "@elewa-website/models/schema/ui/cards";
+
+export const _highlightedNews: NewsItem[] = [
+    {
+      title: "Conversational learning 1",
+      description: "Lorem ipsum dolor sit amet. Vel vitae enim non placeat suscipit qui galisum itaque qui voluptas quia in provident sunt.",
+      buttonText: "Learn More",
+    },
+    {
+      title: "Conversational learning 2",
+      description: "Lorem ipsum dolor sit amet. Vel vitae enim non placeat suscipit",
+      buttonText: "Register Now",
+    },
+    {
+      title: "Conversational learning 3",
+      description: "Lorem ipsum dolor sit amet. Vel vitae enim non placeat suscipit qui galisum itaque qui voluptas quia in provident sunt.",
+      buttonText: "Get Involved",
+    },
+  ];  
+  
+  
+  
+  
+  

--- a/libs/elements/cards/src/lib/cards.module.ts
+++ b/libs/elements/cards/src/lib/cards.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ElewaInfoCardComponent } from './elewa-info-card/elewa-info-card.component';
+import { ElewaNewsCardComponent } from './elewa-news-card/elewa-news-card.component';
+
 @NgModule({
   imports: [CommonModule],
-  declarations: [ElewaInfoCardComponent],
-  exports: [ElewaInfoCardComponent]
+  declarations: [ElewaInfoCardComponent, ElewaNewsCardComponent],
+  exports: [ElewaInfoCardComponent,ElewaNewsCardComponent]
 })
 export class CardsModule {}

--- a/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.html
@@ -1,0 +1,14 @@
+<div class="news-section">
+  <ul>
+    <h2 class="title">News</h2>
+    <li *ngFor="let news of newsData">
+      <div class="list-section">
+        <div class="content">
+          <p class="heading">{{news.title}}</p>
+          <p class="description">{{news.description}}</p>
+        </div>
+        <button class="read-more">{{news.buttonText}}</button>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.scss
@@ -1,0 +1,71 @@
+.news-section {
+  color: black;
+}
+
+.title{
+    font-size: 40px;
+    padding-top: 20px;
+    padding-bottom: 30px;
+}
+
+ul {
+  color: black;
+  display: block;
+  padding: 1em;
+  max-width: 1200px;
+  margin-inline: auto;
+  list-style-type: none;
+  padding-top: 15px;
+  position: relative;
+}
+
+li {
+  padding-top: 10px;
+  border-bottom: 2px solid #40404052;
+  display: flex;
+  justify-content: space-between; 
+  align-items: center;
+}
+
+.list-section {
+  display: flex;
+  align-items: center;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  width: 100%;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  padding: 0 0 10px 10px;
+}
+
+.heading {
+  font-weight: bold;
+  margin-right: 20px; 
+  color: #404040;
+  font-size: 20px;
+  letter-spacing: -0.54px;
+}
+
+.description {
+  letter-spacing: -0.33px;
+  color: #404040;
+  opacity: 0.52;
+  font-size: 16px;
+  text-align: center;
+}
+
+.read-more {
+  margin-left: auto; 
+  font-size: 16px;
+  color: #404040;
+  padding: 0 0 10px 10px;
+  font-weight: bold;
+}
+
+button {
+  border: none;
+  background: none;
+}

--- a/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.spec.ts
+++ b/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ElewaNewsCardComponent } from './elewa-news-card.component';
+
+describe('ElewaNewsCardComponent', () => {
+  let component: ElewaNewsCardComponent;
+  let fixture: ComponentFixture<ElewaNewsCardComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ElewaNewsCardComponent]
+    });
+    fixture = TestBed.createComponent(ElewaNewsCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-card/elewa-news-card.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+import { _highlightedNews as newsContent } from '@elewa-website/data/ui/content-text';
+import { NewsItem } from '@elewa-website/models/schema/ui/cards';
+
+@Component({
+  selector: 'elewa-website-elewa-news-card',
+  templateUrl: './elewa-news-card.component.html',
+  styleUrls: ['./elewa-news-card.component.scss'],
+})
+export class ElewaNewsCardComponent implements OnInit{
+  @Input() newsData!: NewsItem[];
+
+  ngOnInit() {
+    this.newsData = newsContent;
+  }
+}

--- a/libs/models/schema/ui/cards/src/index.ts
+++ b/libs/models/schema/ui/cards/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/info-card.interface';
+export * from './lib/news-card.interface'

--- a/libs/models/schema/ui/cards/src/lib/news-card.interface.ts
+++ b/libs/models/schema/ui/cards/src/lib/news-card.interface.ts
@@ -1,0 +1,5 @@
+export interface NewsItem {
+  title: string;
+  description: string;
+  buttonText: string;
+}


### PR DESCRIPTION
# Description

This is a reusable news item component that can be used to display news items in my presentation. It's mobile friendly

Fixes #11 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot (optional)
![Screenshot at 2023-08-16 13-02-25](https://github.com/italanta/elewa-website/assets/72789911/0e85514e-1b2a-46a8-b1ca-dc8456bdeacd)

## How Has This Been Tested?

The UI of the app matches the design of the XD prototype

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
