### PR TITLE
:sparkles: created the consultancy page module #94

### DIFF
--- a/apps/elewa-website/src/app/app.routing.ts
+++ b/apps/elewa-website/src/app/app.routing.ts
@@ -29,6 +29,13 @@ export const ELEWA_WEBSITE_ROUTES: Route[] = [
         (m) => m.FeaturesPagesAboutModule
       ),
   },
+  {
+    path: 'consultancy',
+    loadChildren: () =>
+      import('@elewa-website/features/pages/consultancy-page').then(
+        (m) => m.ConsultancyPageModule
+      ),
+  },
 ];
 
 @NgModule({

--- a/libs/features/pages/consultancy-page/.eslintrc.json
+++ b/libs/features/pages/consultancy-page/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/pages/consultancy-page/README.md
+++ b/libs/features/pages/consultancy-page/README.md
@@ -1,0 +1,7 @@
+# features-pages-consultancy-page
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-pages-consultancy-page` to execute the unit tests.

--- a/libs/features/pages/consultancy-page/jest.config.ts
+++ b/libs/features/pages/consultancy-page/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-pages-consultancy-page',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory:
+    '../../../../coverage/libs/features/pages/consultancy-page',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/features/pages/consultancy-page/project.json
+++ b/libs/features/pages/consultancy-page/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "features-pages-consultancy-page",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/features/pages/consultancy-page/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/pages/consultancy-page/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/features/pages/consultancy-page/**/*.ts",
+          "libs/features/pages/consultancy-page/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/features/pages/consultancy-page/src/index.ts
+++ b/libs/features/pages/consultancy-page/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/consultancy-page.module';

--- a/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
+++ b/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class ConsultancyPageModule {}

--- a/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
+++ b/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ConsultancyPageComponent } from './main/consultancy-page/consultancy-page.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [ConsultancyPageComponent],
 })
 export class ConsultancyPageModule {}

--- a/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
+++ b/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
+import { ConsultancyRoutingModule } from './consultancy.routing';
+
 import { ConsultancyPageComponent } from './main/consultancy-page/consultancy-page.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, ConsultancyRoutingModule],
   declarations: [ConsultancyPageComponent],
 })
 export class ConsultancyPageModule {}

--- a/libs/features/pages/consultancy-page/src/lib/consultancy.routing.ts
+++ b/libs/features/pages/consultancy-page/src/lib/consultancy.routing.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Route } from '@angular/router';
+
+import { ConsultancyPageComponent } from './main/consultancy-page/consultancy-page.component';
+
+export const ELEWA_CONSULTANCY_ROUTES: Route[] = [
+
+  { path: '', component: ConsultancyPageComponent },
+
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(ELEWA_CONSULTANCY_ROUTES)],
+  exports: [RouterModule]
+})
+export class ConsultancyRoutingModule { }

--- a/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
@@ -1,0 +1,1 @@
+<p>consultancy-page works!</p>

--- a/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.spec.ts
+++ b/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConsultancyPageComponent } from './consultancy-page.component';
+
+describe('ConsultancyPageComponent', () => {
+  let component: ConsultancyPageComponent;
+  let fixture: ComponentFixture<ConsultancyPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConsultancyPageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConsultancyPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.ts
+++ b/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-consultancy-page',
+  templateUrl: './consultancy-page.component.html',
+  styleUrls: ['./consultancy-page.component.scss'],
+})
+export class ConsultancyPageComponent {}

--- a/libs/features/pages/consultancy-page/src/test-setup.ts
+++ b/libs/features/pages/consultancy-page/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/features/pages/consultancy-page/tsconfig.json
+++ b/libs/features/pages/consultancy-page/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/pages/consultancy-page/tsconfig.lib.json
+++ b/libs/features/pages/consultancy-page/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/features/pages/consultancy-page/tsconfig.spec.json
+++ b/libs/features/pages/consultancy-page/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,9 @@
       "@elewa-website/features/pages/about": [
         "libs/features/pages/about/src/index.ts"
       ],
+      "@elewa-website/features/pages/consultancy-page": [
+        "libs/features/pages/consultancy-page/src/index.ts"
+      ],
       "@elewa-website/features/pages/home": [
         "libs/features/pages/home/src/index.ts"
       ],


### PR DESCRIPTION
# Description

I have craeted a /consultacy root route for Consultancy Page module and  added a default child route that renders consultancy page component

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #94

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Screenshot (optional)

**/consultancy renders consultancy component that displays 'consultancy-page-works!'**

![Screenshot from 2023-08-23 17-38-43](https://github.com/italanta/elewa-website/assets/71401172/4f8b4f81-2412-4bc4-b342-7c3a91b0f213)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
