### PR TITLE
:sparkles: Creates booklets page module #91

### DIFF
--- a/apps/elewa-website/src/app/app.routing.ts
+++ b/apps/elewa-website/src/app/app.routing.ts
@@ -29,6 +29,14 @@ export const ELEWA_WEBSITE_ROUTES: Route[] = [
         (m) => m.FeaturesPagesAboutModule
       ),
   },
+
+  {
+    path: 'booklets',
+    loadChildren: () =>
+      import('@elewa-website/features/pages/booklets-page').then(
+        (m) => m.BookletsPageModule
+      ),
+  },
 ];
 
 @NgModule({

--- a/libs/features/pages/booklets-page/.eslintrc.json
+++ b/libs/features/pages/booklets-page/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/pages/booklets-page/README.md
+++ b/libs/features/pages/booklets-page/README.md
@@ -1,0 +1,7 @@
+# features-pages-booklets-page
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-pages-booklets-page` to execute the unit tests.

--- a/libs/features/pages/booklets-page/jest.config.ts
+++ b/libs/features/pages/booklets-page/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-pages-booklets-page',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/features/pages/booklets-page',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/features/pages/booklets-page/project.json
+++ b/libs/features/pages/booklets-page/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "features-pages-booklets-page",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/features/pages/booklets-page/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/pages/booklets-page/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/features/pages/booklets-page/**/*.ts",
+          "libs/features/pages/booklets-page/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/features/pages/booklets-page/src/index.ts
+++ b/libs/features/pages/booklets-page/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/features-pages-booklets-page.module';
+export * from './lib/booklets-page.module';

--- a/libs/features/pages/booklets-page/src/index.ts
+++ b/libs/features/pages/booklets-page/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/features-pages-booklets-page.module';

--- a/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
+++ b/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { BookletsPageComponent } from './main/booklets-page/booklets-page.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [BookletsPageComponent],
 })
 export class BookletsPageModule {}

--- a/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
+++ b/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
 import { BookletsPageComponent } from './main/booklets-page/booklets-page.component';
 
+import { BookletsPageRoutingModule } from './booklets-page.routing';
+
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, BookletsPageRoutingModule],
   declarations: [BookletsPageComponent],
 })
 export class BookletsPageModule {}

--- a/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
+++ b/libs/features/pages/booklets-page/src/lib/booklets-page.module.ts
@@ -4,4 +4,4 @@ import { CommonModule } from '@angular/common';
 @NgModule({
   imports: [CommonModule],
 })
-export class FeaturesPagesBookletsPageModule {}
+export class BookletsPageModule {}

--- a/libs/features/pages/booklets-page/src/lib/booklets-page.routing.ts
+++ b/libs/features/pages/booklets-page/src/lib/booklets-page.routing.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Route } from '@angular/router';
+
+import { BookletsPageComponent } from './main/booklets-page/booklets-page.component';
+
+export const ELEWA_BOOKLETS_PAGE_ROUTES: Route[] = [
+
+  { path: '', component: BookletsPageComponent },
+
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(ELEWA_BOOKLETS_PAGE_ROUTES)],
+  exports: [RouterModule]
+})
+export class BookletsPageRoutingModule { }

--- a/libs/features/pages/booklets-page/src/lib/features-pages-booklets-page.module.ts
+++ b/libs/features/pages/booklets-page/src/lib/features-pages-booklets-page.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class FeaturesPagesBookletsPageModule {}

--- a/libs/features/pages/booklets-page/src/lib/main/booklets-page/booklets-page.component.html
+++ b/libs/features/pages/booklets-page/src/lib/main/booklets-page/booklets-page.component.html
@@ -1,0 +1,1 @@
+<p>booklets-page works!</p>

--- a/libs/features/pages/booklets-page/src/lib/main/booklets-page/booklets-page.component.ts
+++ b/libs/features/pages/booklets-page/src/lib/main/booklets-page/booklets-page.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-booklets-page',
+  templateUrl: './booklets-page.component.html',
+  styleUrls: ['./booklets-page.component.scss'],
+})
+export class BookletsPageComponent {}

--- a/libs/features/pages/booklets-page/src/test-setup.ts
+++ b/libs/features/pages/booklets-page/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/features/pages/booklets-page/tsconfig.json
+++ b/libs/features/pages/booklets-page/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/pages/booklets-page/tsconfig.lib.json
+++ b/libs/features/pages/booklets-page/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/features/pages/booklets-page/tsconfig.spec.json
+++ b/libs/features/pages/booklets-page/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,9 @@
       "@elewa-website/features/pages/about": [
         "libs/features/pages/about/src/index.ts"
       ],
+      "@elewa-website/features/pages/booklets-page": [
+        "libs/features/pages/booklets-page/src/index.ts"
+      ],
       "@elewa-website/features/pages/home": [
         "libs/features/pages/home/src/index.ts"
       ],


### PR DESCRIPTION
This PR generates a booklets page module and its routes where developers can create declarations(components, directives...) that will represent the different sections of the conversational learning page (elewa website). 


Fixes # (issue) - *Example*: Fixes #91, 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshot (optional)
![Screenshot from 2023-08-24 13-44-41](https://github.com/italanta/elewa-website/assets/65117575/5f0b4108-88bd-4e5c-9c7b-2e7e2746c7b3)


## How Has This Been Tested?
No script tests done, just visual tests as shown in the screenshot above


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
