### PR TITLE
:sparkles::art:Create reusable news item component #11

### DIFF
--- a/libs/data/sections/src/index.ts
+++ b/libs/data/sections/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/highlighted-project.data';
+export * from './lib/highlighted-news.data';

--- a/libs/data/sections/src/lib/highlighted-news.data.ts
+++ b/libs/data/sections/src/lib/highlighted-news.data.ts
@@ -1,0 +1,10 @@
+import { NewsItem } from "@elewa-website/models/schema/ui/cards";
+
+/* sample data for the news item card */
+export const __highlightedNews: NewsItem[] = [
+    {
+        title: 'Conversational learning ipsum dolar',
+        description: 'Eos qui ratione voluptatem sequi nesciunt',
+        buttonText: 'Read more'
+    }
+];

--- a/libs/elements/cards/src/lib/cards.module.ts
+++ b/libs/elements/cards/src/lib/cards.module.ts
@@ -5,10 +5,11 @@ import { ButtonsModule } from '@elewa-website/elements/layout/buttons';
 
 import { ElewaInfoCardComponent } from './elewa-info-card/elewa-info-card.component';
 import { ElewaWebsitePriceItemCardComponent } from './elewa-website-price-item-card/elewa-website-price-item-card.component';
+import { ElewaNewsItemCardComponent } from './elewa-news-item-card/elewa-news-item-card.component';
 
 @NgModule({
   imports: [CommonModule, ButtonsModule],
-  declarations: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent],
-  exports: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent],
+  declarations: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaNewsItemCardComponent],
+  exports: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaNewsItemCardComponent],
 })
 export class CardsModule {}

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
@@ -1,0 +1,1 @@
+<p>elewa-news-item-card works!</p>

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
@@ -1,7 +1,7 @@
 <div class="news-item">
-    <ul class="list">
-        <li class="news-list" >
-            <div class="list-section">
+    <ul>
+        <li>
+            <div class="news-list-section">
                 <div class="news-item-card">
                     <p class="title">
                         {{ newsItem.title }}
@@ -9,10 +9,10 @@
                     <p class="description">
                         {{ newsItem.description }}
                     </p>
+                    <p class="button-text">
+                        {{ newsItem.buttonText }}
+                    </p>
                 </div>
-                <button class="button-text">
-                    {{ newsItem.buttonText }}
-                </button>
             </div>
         </li>
     </ul>

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
@@ -1,1 +1,19 @@
-<p>elewa-news-item-card works!</p>
+<div class="news-item">
+    <ul class="list">
+        <li class="news-list" >
+            <div class="list-section">
+                <div class="news-item-card">
+                    <p class="title">
+                        {{ newsItem.title }}
+                    </p>
+                    <p class="description">
+                        {{ newsItem.description }}
+                    </p>
+                </div>
+                <button class="button-text">
+                    {{ newsItem.buttonText }}
+                </button>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.scss
@@ -1,0 +1,49 @@
+.news-item {
+  ul {
+    list-style-type: none;
+    padding: 0;
+
+    li {
+      display: flex;
+      align-items: center;
+      padding: 10px 0;
+      border-bottom: 1px solid #e0e0e0;
+
+      .news-list-section {
+        display: flex;
+        align-items: center;
+        width: 100%;
+
+        .news-item-card {
+          display: flex;
+          align-items: center;
+          flex: 1;
+          padding-right: 20px;
+
+          .title {
+            color: black;
+            font-weight: bold;
+            font-size: 24px;
+            margin-left: 100px;
+            flex: 0.7;
+          }
+
+          .description {
+            color: #808080;
+            font-size: 16px;
+            margin-left: 10%;
+            flex: 1;
+          }
+
+          .button-text {
+            color: black;
+            font-weight: bold;
+            font-size: 14px;
+            cursor: pointer;
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.spec.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaNewsItemCardComponent } from './elewa-news-item-card.component';
+
+describe('ElewaNewsItemCardComponent', () => {
+  let component: ElewaNewsItemCardComponent;
+  let fixture: ComponentFixture<ElewaNewsItemCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ElewaNewsItemCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaNewsItemCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'elewa-website-elewa-news-item-card',
-  standalone: true,
-  imports: [CommonModule],
   templateUrl: './elewa-news-item-card.component.html',
   styleUrls: ['./elewa-news-item-card.component.scss'],
 })

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { NewsItem } from '@elewa-website/models/schema/ui/cards';
 
 @Component({
   selector: 'elewa-website-elewa-news-item-card',
   templateUrl: './elewa-news-item-card.component.html',
   styleUrls: ['./elewa-news-item-card.component.scss'],
 })
-export class ElewaNewsItemCardComponent {}
+export class ElewaNewsItemCardComponent {
+  @Input() newsItem!: NewsItem
+}

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'elewa-website-elewa-news-item-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './elewa-news-item-card.component.html',
+  styleUrls: ['./elewa-news-item-card.component.scss'],
+})
+export class ElewaNewsItemCardComponent {}

--- a/libs/models/schema/ui/cards/src/index.ts
+++ b/libs/models/schema/ui/cards/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/info-card.interface';
 export * from './lib/price-item.interface';
+export * from  './lib/news-item.interface'

--- a/libs/models/schema/ui/cards/src/lib/news-item.interface.ts
+++ b/libs/models/schema/ui/cards/src/lib/news-item.interface.ts
@@ -1,0 +1,5 @@
+export interface NewsItem {
+    title: string
+    description: string
+    buttonText: string
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,8 +16,6 @@
     "baseUrl": ".",
     "paths": {
       "@elewa-website/data/sections": ["libs/data/sections/src/index.ts"],
-      "@elewa-website/elements/cards": ["libs/elements/cards/src/index.ts"],
-  
       "@elewa-website/data/ui/content-text": [
         "libs/data/ui/content-text/src/index.ts"
       ],
@@ -31,7 +29,6 @@
       "@elewa-website/elements/layout/texts": [
         "libs/elements/layout/texts/src/index.ts"
       ],
-
       "@elewa-website/features/pages/about": [
         "libs/features/pages/about/src/index.ts"
       ],
@@ -41,11 +38,11 @@
       "@elewa-website/features/pages/consultancy-page": [
         "libs/features/pages/consultancy-page/src/index.ts"
       ],
-      "@elewa-website/features/pages/content-development": [
-        "libs/features/pages/content-development/src/index.ts"
-      ],
       "@elewa-website/features/pages/contact-page": [
         "libs/features/pages/contact-page/src/index.ts"
+      ],
+      "@elewa-website/features/pages/content-development": [
+        "libs/features/pages/content-development/src/index.ts"
       ],
       "@elewa-website/features/pages/conversational-learning": [
         "libs/features/pages/conversational-learning/src/index.ts"
@@ -53,14 +50,10 @@
       "@elewa-website/features/pages/home": [
         "libs/features/pages/home/src/index.ts"
       ],
-
-      "@elewa-website/models/data/ui": ["libs/models/data/ui/src/index.ts"],
-      "@elewa-website/models/sections/projects": [
-        "libs/models/sections/projects/src/index.ts"
-
       "@elewa-website/features/pages/news-page": [
         "libs/features/pages/news-page/src/index.ts"
       ],
+      "@elewa-website/models/data/ui": ["libs/models/data/ui/src/index.ts"],
       "@elewa-website/models/schema/ui/buttons": [
         "libs/models/schema/ui/buttons/src/index.ts"
       ],
@@ -69,7 +62,12 @@
       ],
       "@elewa-website/models/schema/ui/texts": [
         "libs/models/schema/ui/texts/src/index.ts"
-
+      ],
+      "@elewa-website/models/sections/projects": [
+        "libs/models/sections/projects/src/index.ts"
+      ],
+      "@elewa-website/models/sections/services": [
+        "libs/models/sections/services/src/index.ts"
       ],
       "@elewa-website/models/ui/images": ["libs/models/ui/images/src/index.ts"]
     }


### PR DESCRIPTION
# Description

This pull request enhances the styling and layout of the reusable News Item component to improve the visual presentation and alignment of the title, description, and button elements.

Fixes #11 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot (optional)

![Screenshot from 2023-08-25 13-31-06](https://github.com/italanta/elewa-website/assets/117742892/480c7053-c5e9-4d2e-835e-7cb23857918e)

## How Has This Been Tested?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
