### PR TITLE
News item component

### DIFF
--- a/apps/elewa-website/src/environments/environment.prod.ts.example
+++ b/apps/elewa-website/src/environments/environment.prod.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: true,
-};

--- a/libs/data/sections/src/lib/highlighted-news.data.ts
+++ b/libs/data/sections/src/lib/highlighted-news.data.ts
@@ -1,0 +1,9 @@
+import { NewsItem } from "@elewa-website/models/schema/ui/cards";
+
+export const __highlightedNews: NewsItem[] = [
+    {
+        title: 'Conversational learning ipsum dolar',
+        description: 'Eos qui ratione voluptatem sequi nesciunt',
+        buttonText: 'Read more'
+    }
+]

--- a/libs/elements/cards/src/lib/cards.module.ts
+++ b/libs/elements/cards/src/lib/cards.module.ts
@@ -6,10 +6,20 @@ import { ButtonsModule } from '@elewa-website/elements/layout/buttons';
 import { ElewaInfoCardComponent } from './elewa-info-card/elewa-info-card.component';
 import { ElewaProjectItemCardComponent } from './elewa-project-item-card/elewa-project-item-card.component';
 import { ElewaWebsitePriceItemCardComponent } from './elewa-price-item-card/elewa-website-price-item-card.component';
+import { ElewaNewsItemCardComponent } from './elewa-news-item-card/elewa-news-item-card.component';
 
 @NgModule({
   imports: [CommonModule, ButtonsModule],
-  declarations: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaProjectItemCardComponent],
-  exports: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaProjectItemCardComponent],
+  declarations: [
+    ElewaInfoCardComponent,
+    ElewaWebsitePriceItemCardComponent,
+    ElewaProjectItemCardComponent,
+    ElewaNewsItemCardComponent,
+  ],
+  exports: [
+    ElewaInfoCardComponent,
+    ElewaWebsitePriceItemCardComponent,
+    ElewaProjectItemCardComponent,
+  ],
 })
 export class CardsModule {}

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
@@ -1,0 +1,1 @@
+<p>elewa-news-item-card works!</p>

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.html
@@ -1,1 +1,5 @@
-<p>elewa-news-item-card works!</p>
+<<div class="news">
+    <div class="title">{{ newsitem.title }}</div>
+    <div class="descr">{{ newsitem.description }}</div>
+    <div class="button">{{ newsitem.buttonText }}</div>
+</div>

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.scss
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.scss
@@ -1,0 +1,23 @@
+.news
+{
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+}
+
+.title
+{
+    font-weight: bold;
+    font-size: 20px;
+}
+
+.descr
+{
+    font-size: 14px;
+}
+
+.button
+{
+    font-size: 14px;
+    font-weight: bold;
+}

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.spec.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaNewsItemCardComponent } from './elewa-news-item-card.component';
+
+describe('ElewaNewsItemCardComponent', () => {
+  let component: ElewaNewsItemCardComponent;
+  let fixture: ComponentFixture<ElewaNewsItemCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaNewsItemCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaNewsItemCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-news-item-card',
+  templateUrl: './elewa-news-item-card.component.html',
+  styleUrls: ['./elewa-news-item-card.component.scss'],
+})
+export class ElewaNewsItemCardComponent {}

--- a/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
+++ b/libs/elements/cards/src/lib/elewa-news-item-card/elewa-news-item-card.component.ts
@@ -1,8 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { NewsItem } from '@elewa-website/models/schema/ui/cards';
 
 @Component({
   selector: 'elewa-website-elewa-news-item-card',
   templateUrl: './elewa-news-item-card.component.html',
   styleUrls: ['./elewa-news-item-card.component.scss'],
 })
-export class ElewaNewsItemCardComponent {}
+export class ElewaNewsItemCardComponent {
+  @Input() newsitem! : NewsItem
+}

--- a/libs/models/schema/ui/cards/src/index.ts
+++ b/libs/models/schema/ui/cards/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/info-card.interface';
 export * from './lib/price-item.interface';
+export * from './lib/news-item.interface'

--- a/libs/models/schema/ui/cards/src/lib/news-item.interface.ts
+++ b/libs/models/schema/ui/cards/src/lib/news-item.interface.ts
@@ -1,0 +1,5 @@
+export interface NewsItem {
+    title: string
+    description: string
+    buttonText: string
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,16 +15,16 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@elewa-website/data/sections": ["libs/data/sections/src/index.ts"],
       "@elewa-website/data/ui/content-text": [
         "libs/data/ui/content-text/src/index.ts"
       ],
-      "@elewa-website/data/sections": ["libs/data/sections/src/index.ts"],
       "@elewa-website/elements/cards": ["libs/elements/cards/src/index.ts"],
-      "@elewa-website/elements/layout/carousel": [
-        "libs/elements/layout/carousel/src/index.ts"
-      ],
       "@elewa-website/elements/layout/buttons": [
         "libs/elements/layout/buttons/src/index.ts"
+      ],
+      "@elewa-website/elements/layout/carousel": [
+        "libs/elements/layout/carousel/src/index.ts"
       ],
       "@elewa-website/elements/layout/header": [
         "libs/elements/layout/header/src/index.ts"
@@ -41,11 +41,11 @@
       "@elewa-website/features/pages/consultancy-page": [
         "libs/features/pages/consultancy-page/src/index.ts"
       ],
-      "@elewa-website/features/pages/content-development": [
-        "libs/features/pages/content-development/src/index.ts"
-      ],
       "@elewa-website/features/pages/contact-page": [
         "libs/features/pages/contact-page/src/index.ts"
+      ],
+      "@elewa-website/features/pages/content-development": [
+        "libs/features/pages/content-development/src/index.ts"
       ],
       "@elewa-website/features/pages/conversational-learning": [
         "libs/features/pages/conversational-learning/src/index.ts"
@@ -56,9 +56,6 @@
       "@elewa-website/features/pages/news-page": [
         "libs/features/pages/news-page/src/index.ts"
       ],
-      "@elewa-website/models/sections/projects": [
-        "libs/models/sections/projects/src/index.ts"
-      ],
       "@elewa-website/models/schema/ui/buttons": [
         "libs/models/schema/ui/buttons/src/index.ts"
       ],
@@ -67,6 +64,9 @@
       ],
       "@elewa-website/models/schema/ui/texts": [
         "libs/models/schema/ui/texts/src/index.ts"
+      ],
+      "@elewa-website/models/sections/projects": [
+        "libs/models/sections/projects/src/index.ts"
       ],
       "@elewa-website/models/ui/images": ["libs/models/ui/images/src/index.ts"]
     }


### PR DESCRIPTION
# Description

As a developer, I want a reusable news-item component that I can use to render news section texts i.e title and description for the different pages in our app.

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #11 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshot (optional)
![Screenshot from 2023-08-25 14-49-16](https://github.com/italanta/elewa-website/assets/136768250/10bb233b-0021-431a-8e77-22f22c77c16a)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
