### PR TITLE
Reusable-team-member-component-#124

### DIFF
--- a/apps/elewa-website/src/environments/environment.prod.ts.example
+++ b/apps/elewa-website/src/environments/environment.prod.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: true,
-};

--- a/apps/elewa-website/src/environments/environment.ts.example
+++ b/apps/elewa-website/src/environments/environment.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: false,
-};

--- a/libs/elements/cards/src/lib/cards.module.ts
+++ b/libs/elements/cards/src/lib/cards.module.ts
@@ -6,10 +6,21 @@ import { ButtonsModule } from '@elewa-website/elements/layout/buttons';
 import { ElewaInfoCardComponent } from './elewa-info-card/elewa-info-card.component';
 import { ElewaProjectItemCardComponent } from './elewa-project-item-card/elewa-project-item-card.component';
 import { ElewaWebsitePriceItemCardComponent } from './elewa-price-item-card/elewa-website-price-item-card.component';
+import { TeamMemberCardComponent } from './team-member-card/team-member-card.component';
 
 @NgModule({
   imports: [CommonModule, ButtonsModule],
-  declarations: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaProjectItemCardComponent],
-  exports: [ElewaInfoCardComponent, ElewaWebsitePriceItemCardComponent, ElewaProjectItemCardComponent],
+  declarations: [
+    ElewaInfoCardComponent,
+    ElewaWebsitePriceItemCardComponent,
+    ElewaProjectItemCardComponent,
+    TeamMemberCardComponent,
+  ],
+  exports: [
+    ElewaInfoCardComponent,
+    ElewaWebsitePriceItemCardComponent,
+    ElewaProjectItemCardComponent,
+    TeamMemberCardComponent
+  ],
 })
 export class CardsModule {}

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.html
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.html
@@ -1,0 +1,1 @@
+<p>team-member-card works!</p>

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.html
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.html
@@ -1,1 +1,17 @@
-<p>team-member-card works!</p>
+ <!--  properties for member object -->
+
+<div class="card-container">
+  <div class="card">
+    <div class="card-image">
+      <img
+        [src]="member.imgSrc"
+        ngSrcset="100w, 200w, 300w"
+        sizes="(max-width: 480px) 100vw,
+        (max-width: 768px) 50vw,
+        33.3vw"
+        [alt]="member.fullName"
+      />
+    </div>
+    <div class="card-title">{{ member.fullName }}</div>
+  </div>
+</div>

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.scss
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.scss
@@ -1,0 +1,39 @@
+.card-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+}
+
+.card {
+  width: 100%;
+  max-width: 200px;
+  background-color: var(--backgroundColor, #f8f4fb);
+}
+
+.card-image img {
+  margin-top: 16px;
+  padding: 4px;
+  width: 100%;
+  height: 240px;
+  border-radius: 96px;
+  
+}
+
+.card-title {
+  padding: 10px;
+  text-align: center;
+  color: var(--amountColor, black);
+  font-size: 24px;
+}
+
+/* Responsivensss */
+
+@media (max-width:480px) {
+
+  /* small size fonts in phones */
+  .card-title{
+    font-size: 16px;
+  }
+  
+}

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.spec.ts
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TeamMemberCardComponent } from './team-member-card.component';
+
+describe('TeamMemberCardComponent', () => {
+  let component: TeamMemberCardComponent;
+  let fixture: ComponentFixture<TeamMemberCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TeamMemberCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TeamMemberCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.ts
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-team-member-card',
+  templateUrl: './team-member-card.component.html',
+  styleUrls: ['./team-member-card.component.scss'],
+})
+export class TeamMemberCardComponent {}

--- a/libs/elements/cards/src/lib/team-member-card/team-member-card.component.ts
+++ b/libs/elements/cards/src/lib/team-member-card/team-member-card.component.ts
@@ -1,8 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, Input} from '@angular/core';
+import { TeamMemberInterface } from '@elewa-website/models/schema/ui/cards';
 
 @Component({
   selector: 'elewa-website-team-member-card',
   templateUrl: './team-member-card.component.html',
   styleUrls: ['./team-member-card.component.scss'],
 })
-export class TeamMemberCardComponent {}
+export class TeamMemberCardComponent {
+
+  /**  Pass member property as input in the component */
+  @Input() member!: TeamMemberInterface;
+}
+

--- a/libs/models/schema/ui/cards/src/index.ts
+++ b/libs/models/schema/ui/cards/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/info-card.interface';
 export * from './lib/price-item.interface';
+export * from './lib/team-member.interface';

--- a/libs/models/schema/ui/cards/src/lib/team-member.interface.ts
+++ b/libs/models/schema/ui/cards/src/lib/team-member.interface.ts
@@ -1,0 +1,6 @@
+export interface TeamMemberInterface {
+
+    fullName: string
+    imgSrc: string
+
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,16 +15,16 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@elewa-website/data/sections": ["libs/data/sections/src/index.ts"],
       "@elewa-website/data/ui/content-text": [
         "libs/data/ui/content-text/src/index.ts"
       ],
-      "@elewa-website/data/sections": ["libs/data/sections/src/index.ts"],
       "@elewa-website/elements/cards": ["libs/elements/cards/src/index.ts"],
-      "@elewa-website/elements/layout/carousel": [
-        "libs/elements/layout/carousel/src/index.ts"
-      ],
       "@elewa-website/elements/layout/buttons": [
         "libs/elements/layout/buttons/src/index.ts"
+      ],
+      "@elewa-website/elements/layout/carousel": [
+        "libs/elements/layout/carousel/src/index.ts"
       ],
       "@elewa-website/elements/layout/header": [
         "libs/elements/layout/header/src/index.ts"
@@ -41,11 +41,11 @@
       "@elewa-website/features/pages/consultancy-page": [
         "libs/features/pages/consultancy-page/src/index.ts"
       ],
-      "@elewa-website/features/pages/content-development": [
-        "libs/features/pages/content-development/src/index.ts"
-      ],
       "@elewa-website/features/pages/contact-page": [
         "libs/features/pages/contact-page/src/index.ts"
+      ],
+      "@elewa-website/features/pages/content-development": [
+        "libs/features/pages/content-development/src/index.ts"
       ],
       "@elewa-website/features/pages/conversational-learning": [
         "libs/features/pages/conversational-learning/src/index.ts"
@@ -56,9 +56,6 @@
       "@elewa-website/features/pages/news-page": [
         "libs/features/pages/news-page/src/index.ts"
       ],
-      "@elewa-website/models/sections/projects": [
-        "libs/models/sections/projects/src/index.ts"
-      ],
       "@elewa-website/models/schema/ui/buttons": [
         "libs/models/schema/ui/buttons/src/index.ts"
       ],
@@ -67,6 +64,9 @@
       ],
       "@elewa-website/models/schema/ui/texts": [
         "libs/models/schema/ui/texts/src/index.ts"
+      ],
+      "@elewa-website/models/sections/projects": [
+        "libs/models/sections/projects/src/index.ts"
       ],
       "@elewa-website/models/ui/images": ["libs/models/ui/images/src/index.ts"]
     }


### PR DESCRIPTION
### **Description**
This component is to be reused throughout the site to display team members in a carousel. Exported through cards module, it is available all-over the app.It is responsive o screens,tabs and phones.


Fixes # 124

## Type of change


- [x] New feature (non-breaking change which adds functionality)


## Screenshot (optional)
![ss1](https://github.com/italanta/elewa-website/assets/111140962/2690a394-ad8c-47da-8500-46f9ac6b5068)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
