### PR TITLE
Reusable image container #19

### DIFF
--- a/libs/elements/layout/images/.eslintrc.json
+++ b/libs/elements/layout/images/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/elements/layout/images/README.md
+++ b/libs/elements/layout/images/README.md
@@ -1,0 +1,7 @@
+# elements-layout-images
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test elements-layout-images` to execute the unit tests.

--- a/libs/elements/layout/images/jest.config.ts
+++ b/libs/elements/layout/images/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'elements-layout-images',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/elements/layout/images',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/elements/layout/images/project.json
+++ b/libs/elements/layout/images/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "elements-layout-images",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/elements/layout/images/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/elements/layout/images/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/elements/layout/images/**/*.ts",
+          "libs/elements/layout/images/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/elements/layout/images/src/index.ts
+++ b/libs/elements/layout/images/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/elements-layout-images.module';

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -1,0 +1,1 @@
+<p>elewa-image-container works!</p>

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -9,7 +9,7 @@
   </div>
   <div class="window">
     <h2>{{ window.title }}</h2>
-    <img src="{{ window.imageSrc }}" alt="" />
+    <img class="windowed" src="{{ window.imageSrc }}" alt="" />
   </div>
   <div class="card">
     <h2>{{ card.title }}</h2>

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="pill">
     <h2>{{ pill.title }}</h2>
-    <img src="{{ pill.imageSrc }}" alt="" />
+    <img class="pilled" src="{{ pill.imageSrc }}" alt="" />
   </div>
   <div class="stacked">
     <h2>{{ stacked.title }}</h2>

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -13,7 +13,7 @@
   </div>
   <div class="card">
     <h2>{{ card.title }}</h2>
-    <img src="{{ card.imageSrc }}" alt="" />
+    <img class="carded" src="{{ card.imageSrc }}" alt="" />
   </div>
 </div>
 

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -5,7 +5,7 @@
   </div>
   <div class="stacked">
     <h2>{{ stacked.title }}</h2>
-    <img src="{{ stacked.imageSrc }}" alt="" />
+    <img class="stack" src="{{ stacked.imageSrc }}" alt="" />
   </div>
   <div class="window">
     <h2>{{ window.title }}</h2>
@@ -16,3 +16,12 @@
     <img src="{{ card.imageSrc }}" alt="" />
   </div>
 </div>
+
+<svg>
+  <defs>
+    <clipPath id="clip">
+      <ellipse cx="200" cy="50" rx="200" ry="150" ></ellipse>
+      <ellipse cx="200" cy="250" rx="200" ry="150" ></ellipse>
+    </clipPath>
+  </defs>
+</svg>

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.html
@@ -1,1 +1,18 @@
-<p>elewa-image-container works!</p>
+<div class="container">
+  <div class="pill">
+    <h2>{{ pill.title }}</h2>
+    <img src="{{ pill.imageSrc }}" alt="" />
+  </div>
+  <div class="stacked">
+    <h2>{{ stacked.title }}</h2>
+    <img src="{{ stacked.imageSrc }}" alt="" />
+  </div>
+  <div class="window">
+    <h2>{{ window.title }}</h2>
+    <img src="{{ window.imageSrc }}" alt="" />
+  </div>
+  <div class="card">
+    <h2>{{ card.title }}</h2>
+    <img src="{{ card.imageSrc }}" alt="" />
+  </div>
+</div>

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -36,4 +36,13 @@
         clip-path: ellipse(60% 80% at 50% 80%);
     }
   }
+  .card{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    .carded{
+        clip-path: inset(20px 50px);
+    }
+  }
 }

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -46,3 +46,18 @@
     }
   }
 }
+
+@media (max-width: 480px) {
+    .container{
+        display: flex;
+        flex-direction: column;
+        width: 90%;
+        position: relative;
+        top: 2rem;
+        left: 1rem;
+        .pill, .card, .stacked, .window{
+            padding: 2rem;
+        }
+    }
+   
+}

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -18,4 +18,13 @@
       object-fit: cover;
     }
   }
+  .stacked{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    .stack{
+        clip-path: url(#clip);
+    }
+  }
 }

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -1,0 +1,21 @@
+.container {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  img {
+    width: 25rem;
+    height: 20rem;
+    margin: 2rem;
+  }
+  .pill {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    .pilled {
+      clip-path: ellipse(30% 50% at center);
+      object-fit: cover;
+    }
+  }
+}

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -27,4 +27,13 @@
         clip-path: url(#clip);
     }
   }
+  .window{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    .windowed{
+        clip-path: ellipse(60% 80% at 50% 80%);
+    }
+  }
 }

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.scss
@@ -33,7 +33,7 @@
     align-items: center;
     justify-content: center;
     .windowed{
-        clip-path: ellipse(60% 80% at 50% 80%);
+        clip-path: ellipse(70% 80% at 50% 80%);
     }
   }
   .card{
@@ -42,7 +42,8 @@
     align-items: center;
     justify-content: center;
     .carded{
-        clip-path: inset(20px 50px);
+        // clip-path: inset(20px 50px);
+        clip-path: circle(15.8rem at center);
     }
   }
 }

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.spec.ts
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaImageContainerComponent } from './elewa-image-container.component';
+
+describe('ElewaImageContainerComponent', () => {
+  let component: ElewaImageContainerComponent;
+  let fixture: ComponentFixture<ElewaImageContainerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaImageContainerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaImageContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-image-container',
+  templateUrl: './elewa-image-container.component.html',
+  styleUrls: ['./elewa-image-container.component.scss'],
+})
+export class ElewaImageContainerComponent {}

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
@@ -9,22 +9,22 @@ import { ImageConfig } from '../../../../../../../models/schema/ui/images/image-
 export class ElewaImageContainerComponent {
   pill: ImageConfig = {
     title: 'Pill',
-    imageSrc: '',
+    imageSrc: 'https://media.gettyimages.com/id/1346973410/photo/young-woman-at-a-library.jpg?s=612x612&w=0&k=20&c=PW6KYwtS3oUx1mPcbfyqDcZotnyjFO-cwfbOsyG2ERk=',
     visualisation: 0,
   };
   stacked: ImageConfig = {
     title: 'Stacked',
-    imageSrc: '',
+    imageSrc: 'https://media.istockphoto.com/id/1178524829/photo/young-woman-making-choice-donut-or-apple.jpg?s=612x612&w=0&k=20&c=WeZ6-DQ8npDAhDNDZkcE48gtFFbqfTIIvpAfSfsh0Uo=',
     visualisation: 1,
   };
   window: ImageConfig = {
     title: 'Window',
-    imageSrc: '',
+    imageSrc: 'https://media.gettyimages.com/id/1392205193/photo/brazilian-man-working-and-using-technology-in-the-field.jpg?s=2048x2048&w=gi&k=20&c=3ACQa-OGvMCBa-bJ0TjeVb-Y820Ys2IEwimShEDFYm0=',
     visualisation: 2,
   };
   card: ImageConfig = {
     title: 'Card',
-    imageSrc: '',
+    imageSrc: 'https://media.gettyimages.com/id/1017628288/photo/happy-african-family-together-using-laptop.jpg?s=2048x2048&w=gi&k=20&c=fcjastVF8goNKDaqdzqzqMEW9Xf6xQKMCWH2wEAy2WA=',
     visualisation: 3,
   };
 }

--- a/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
+++ b/libs/elements/layout/images/src/lib/components/elewa-image-container/elewa-image-container.component.ts
@@ -1,8 +1,30 @@
 import { Component } from '@angular/core';
+import { ImageConfig } from '../../../../../../../models/schema/ui/images/image-config.interface';
 
 @Component({
   selector: 'elewa-website-elewa-image-container',
   templateUrl: './elewa-image-container.component.html',
   styleUrls: ['./elewa-image-container.component.scss'],
 })
-export class ElewaImageContainerComponent {}
+export class ElewaImageContainerComponent {
+  pill: ImageConfig = {
+    title: 'Pill',
+    imageSrc: '',
+    visualisation: 0,
+  };
+  stacked: ImageConfig = {
+    title: 'Stacked',
+    imageSrc: '',
+    visualisation: 1,
+  };
+  window: ImageConfig = {
+    title: 'Window',
+    imageSrc: '',
+    visualisation: 2,
+  };
+  card: ImageConfig = {
+    title: 'Card',
+    imageSrc: '',
+    visualisation: 3,
+  };
+}

--- a/libs/elements/layout/images/src/lib/elements-layout-images.module.ts
+++ b/libs/elements/layout/images/src/lib/elements-layout-images.module.ts
@@ -5,5 +5,6 @@ import { ElewaImageContainerComponent } from './components/elewa-image-container
 @NgModule({
   imports: [CommonModule],
   declarations: [ElewaImageContainerComponent],
+  exports: [ElewaImageContainerComponent],
 })
 export class ElementsLayoutImagesModule {}

--- a/libs/elements/layout/images/src/lib/elements-layout-images.module.ts
+++ b/libs/elements/layout/images/src/lib/elements-layout-images.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ElewaImageContainerComponent } from './components/elewa-image-container/elewa-image-container.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ElewaImageContainerComponent],
+})
+export class ElementsLayoutImagesModule {}

--- a/libs/elements/layout/images/src/test-setup.ts
+++ b/libs/elements/layout/images/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/elements/layout/images/tsconfig.json
+++ b/libs/elements/layout/images/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/elements/layout/images/tsconfig.lib.json
+++ b/libs/elements/layout/images/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/elements/layout/images/tsconfig.spec.json
+++ b/libs/elements/layout/images/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/features/pages/home/src/lib/components/news-section/news-section.component.html
+++ b/libs/features/pages/home/src/lib/components/news-section/news-section.component.html
@@ -1,10 +1,11 @@
 <section class="container">
-  <div class="news-section">
+  <!-- <div class="news-section">
     <h2 class="section-title">News</h2>
 
     <ng-container *ngFor="let item of highlightedNews; let last = last">
       <elewa-website-elewa-news-item-card [item]="item"></elewa-website-elewa-news-item-card>
-      <hr class="news-item-separator" /> <!-- Separator is displayed after each item -->
+      <hr class="news-item-separator" /> Separator is displayed after each item
     </ng-container>
-  </div>
+  </div> -->
+  <elewa-website-elewa-image-container></elewa-website-elewa-image-container>
 </section>

--- a/libs/features/pages/home/src/lib/features-pages-home.module.ts
+++ b/libs/features/pages/home/src/lib/features-pages-home.module.ts
@@ -8,9 +8,10 @@ import { HomePageComponent } from './main/home/home-page.component';
 import { NewsSectionComponent } from './components/news-section/news-section.component';
 
 import { HomeRoutingModule } from './home.routing';
+import { ElementsLayoutImagesModule } from '@elewa-website/elements/layout/images';
 
 @NgModule({
-  imports: [CommonModule, HomeRoutingModule, CardsModule, AppHeaderModule],
+  imports: [CommonModule, HomeRoutingModule, CardsModule, AppHeaderModule, ElementsLayoutImagesModule],
   declarations: [HomePageComponent, NewsSectionComponent],
   exports: [HomePageComponent],
 })

--- a/libs/models/schema/ui/images/image-config.interface.ts
+++ b/libs/models/schema/ui/images/image-config.interface.ts
@@ -1,2 +1,13 @@
-export interface ImageConfigInterface {
-}
+export interface ImageConfig {
+    title: string
+    imageSrc: string
+    visualisation: ImageVisualisation
+    maxWidth?: string
+  }
+  
+  export enum ImageVisualisation {
+    Pill = 0,
+    stacked = 1,
+    Window = 2,
+    Card = 3
+  }

--- a/libs/models/schema/ui/images/image-config.interface.ts
+++ b/libs/models/schema/ui/images/image-config.interface.ts
@@ -1,0 +1,2 @@
+export interface ImageConfigInterface {
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,9 @@
       "@elewa-website/elements/layout/header": [
         "libs/elements/layout/header/src/index.ts"
       ],
+      "@elewa-website/elements/layout/images": [
+        "libs/elements/layout/images/src/index.ts"
+      ],
       "@elewa-website/elements/layout/texts": [
         "libs/elements/layout/texts/src/index.ts"
       ],


### PR DESCRIPTION
# Description

Creates an image-container component that uses clip-path to deliver the below forms:
- **Pill**: The pill is an oval rounded shape with the roundings being on the top and bottom (rounding of each corner is 30% of window height)
- **Stacked**: The stacked cuts out two horizontal pills
- **Window**: A window rounds at the top only (rounding is 30% of height)
- **Card**: A card image only rounds slightly (5 to 10px)

Reference the issue related to this PR as shown below. 
(https://github.com/italanta/elewa-website/issues/19).


## Screenshot (optional)
![image](https://github.com/italanta/elewa-website/assets/52041084/d22d690d-2288-411f-b792-7b7eb6f296cf)
![image](https://github.com/italanta/elewa-website/assets/52041084/4c2b9576-8fca-4057-bae7-13e557363138)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
