### PR TITLE
:lipstick: :sparkles: Created reusable image and text banner #8

### DIFF
--- a/libs/elements/banners/.eslintrc.json
+++ b/libs/elements/banners/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/elements/banners/README.md
+++ b/libs/elements/banners/README.md
@@ -1,0 +1,7 @@
+# elements-banners
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test elements-banners` to execute the unit tests.

--- a/libs/elements/banners/jest.config.ts
+++ b/libs/elements/banners/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'elements-banners',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../coverage/libs/elements/banners',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/elements/banners/project.json
+++ b/libs/elements/banners/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "elements-banners",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/elements/banners/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/elements/banners/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/elements/banners/**/*.ts",
+          "libs/elements/banners/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/elements/banners/src/index.ts
+++ b/libs/elements/banners/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/elements-banners.module';

--- a/libs/elements/banners/src/index.ts
+++ b/libs/elements/banners/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/elements-banners.module';
+export * from './lib/banners.module';

--- a/libs/elements/banners/src/lib/banners.module.ts
+++ b/libs/elements/banners/src/lib/banners.module.ts
@@ -9,5 +9,6 @@ import { ElewaImageAndTextBannerComponent } from './components/elewa-image-and-t
 @NgModule({
   imports: [CommonModule, ImagesModule, TextsModule],
   declarations: [ElewaImageAndTextBannerComponent],
+  exports:[ElewaImageAndTextBannerComponent]
 })
-export class ElementsBannersModule {}
+export class BannersModule {}

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.html
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.html
@@ -1,0 +1,1 @@
+<p>elewa-image-and-text-banner works!</p>

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.html
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.html
@@ -1,1 +1,23 @@
-<p>elewa-image-and-text-banner works!</p>
+<div class="banner-container">
+    <div class="banner">
+
+    <div class="banner-left" [ngStyle]="getPositionStyle(imageAndText.imagePosition)">
+        <div class="banner-image">
+        <elewa-website-image-container
+            [imageConfig]="imageAndText.image"
+        >
+        </elewa-website-image-container>
+        </div>
+    </div>
+
+    <div class="banner-right">
+        <div class="banner-content">
+            <elewa-website-elewa-text-content-item
+                [content]="imageAndText.content"
+            >
+            </elewa-website-elewa-text-content-item>
+        </div>
+    </div>
+    </div>
+
+</div>

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.scss
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.scss
@@ -1,0 +1,36 @@
+.banner-container{
+    
+    justify-content: center; /* Center horizontally */
+    align-items: center; /* Center vertically */
+    height: 100vh; /* Make the body take up the entire viewport height */
+    margin: 0;
+    padding: 50px;
+    
+}
+
+.banner{
+    display: flex;
+    justify-content: center; /* Center horizontally */
+    align-items: center; 
+    height:100%;
+
+}
+
+
+
+.banner-left{
+    width:50%;
+}
+
+.banner-image{
+    width: 100%;    
+   margin-left: auto;
+}
+
+.banner-right{
+    width:50%;
+}
+
+.banner-content{
+    width:100%;
+}

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.spec.ts
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaImageAndTextBannerComponent } from './elewa-image-and-text-banner.component';
+
+describe('ElewaImageAndTextBannerComponent', () => {
+  let component: ElewaImageAndTextBannerComponent;
+  let fixture: ComponentFixture<ElewaImageAndTextBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaImageAndTextBannerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaImageAndTextBannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
@@ -1,8 +1,30 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { ImageAndText } from '@elewa-website/models/schema/ui/banners';
 
 @Component({
   selector: 'elewa-website-elewa-image-and-text-banner',
   templateUrl: './elewa-image-and-text-banner.component.html',
   styleUrls: ['./elewa-image-and-text-banner.component.scss'],
 })
-export class ElewaImageAndTextBannerComponent {}
+export class ElewaImageAndTextBannerComponent {
+  @Input() imageAndText!: ImageAndText;
+
+  /**
+   * Calculates the CSS style for positioning the image within the banner.
+   *
+   * @param {string} imagePosition - The desired position of the image ('left', 'right', or other).
+   * @returns {Object} An object representing the CSS style.
+   * @memberof ElewaImageAndTextBannerComponent
+   */
+  getPositionStyle(imagePosition: string): { [key: string]: string } {
+    switch (imagePosition) {
+      case 'left':
+        return { 'order': '1' };
+      case 'right':
+        return { 'order': '2' };
+      default:
+        return { 'order': '0' }; // default value
+    }
+  }
+}

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-image-and-text-banner',
+  templateUrl: './elewa-image-and-text-banner.component.html',
+  styleUrls: ['./elewa-image-and-text-banner.component.scss'],
+})
+export class ElewaImageAndTextBannerComponent {}

--- a/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
+++ b/libs/elements/banners/src/lib/components/elewa-image-and-text-banner/elewa-image-and-text-banner.component.ts
@@ -20,9 +20,9 @@ export class ElewaImageAndTextBannerComponent {
   getPositionStyle(imagePosition: string): { [key: string]: string } {
     switch (imagePosition) {
       case 'left':
-        return { 'order': '1' };
+        return { 'order': '0' };
       case 'right':
-        return { 'order': '2' };
+        return { 'order': '1' };
       default:
         return { 'order': '0' }; // default value
     }

--- a/libs/elements/banners/src/lib/elements-banners.module.ts
+++ b/libs/elements/banners/src/lib/elements-banners.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class ElementsBannersModule {}

--- a/libs/elements/banners/src/lib/elements-banners.module.ts
+++ b/libs/elements/banners/src/lib/elements-banners.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ElewaImageAndTextBannerComponent } from './components/elewa-image-and-text-banner/elewa-image-and-text-banner.component';
 
 @NgModule({
   imports: [CommonModule],
+  declarations: [ElewaImageAndTextBannerComponent],
 })
 export class ElementsBannersModule {}

--- a/libs/elements/banners/src/lib/elements-banners.module.ts
+++ b/libs/elements/banners/src/lib/elements-banners.module.ts
@@ -1,9 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
+import { ImagesModule } from '@elewa-website/elements/layout/images';
+import { TextsModule } from '@elewa-website/elements/layout/texts';
+
 import { ElewaImageAndTextBannerComponent } from './components/elewa-image-and-text-banner/elewa-image-and-text-banner.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, ImagesModule, TextsModule],
   declarations: [ElewaImageAndTextBannerComponent],
 })
 export class ElementsBannersModule {}

--- a/libs/elements/banners/src/test-setup.ts
+++ b/libs/elements/banners/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/elements/banners/tsconfig.json
+++ b/libs/elements/banners/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/elements/banners/tsconfig.lib.json
+++ b/libs/elements/banners/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/elements/banners/tsconfig.spec.json
+++ b/libs/elements/banners/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/elements/layout/texts/src/lib/texts.module.ts
+++ b/libs/elements/layout/texts/src/lib/texts.module.ts
@@ -6,6 +6,7 @@ import { ElewaTextContentItemComponent } from './components/elewa-text-content-i
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ElewaTextContentItemComponent, ElewaTextSectionComponent]
+  declarations: [ElewaTextContentItemComponent, ElewaTextSectionComponent],
+  exports: [ElewaTextContentItemComponent]
 })
 export class TextsModule {}

--- a/libs/models/schema/ui/banners/.eslintrc.json
+++ b/libs/models/schema/ui/banners/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "elewaWebsite",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "elewa-website",
+            "style": "kebab-case"
+          }
+        ]
+      },
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ]
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/models/schema/ui/banners/README.md
+++ b/libs/models/schema/ui/banners/README.md
@@ -1,0 +1,7 @@
+# models-schema-ui-banners
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test models-schema-ui-banners` to execute the unit tests.

--- a/libs/models/schema/ui/banners/jest.config.ts
+++ b/libs/models/schema/ui/banners/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'models-schema-ui-banners',
+  preset: '../../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../../coverage/libs/models/schema/ui/banners',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/models/schema/ui/banners/project.json
+++ b/libs/models/schema/ui/banners/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "models-schema-ui-banners",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/models/schema/ui/banners/src",
+  "prefix": "elewa-website",
+  "tags": [],
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/models/schema/ui/banners/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/models/schema/ui/banners/**/*.ts",
+          "libs/models/schema/ui/banners/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/models/schema/ui/banners/src/index.ts
+++ b/libs/models/schema/ui/banners/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ImageAndText';

--- a/libs/models/schema/ui/banners/src/lib/ImageAndText.ts
+++ b/libs/models/schema/ui/banners/src/lib/ImageAndText.ts
@@ -1,0 +1,8 @@
+import { ContentText } from "@elewa-website/models/schema/ui/texts"
+import { ImageConfig } from "@elewa-website/models/schema/ui/images"
+
+export interface ImageAndText {
+  content: ContentText
+  image: ImageConfig
+  imagePosition: 'left' | 'right'
+}

--- a/libs/models/schema/ui/banners/src/test-setup.ts
+++ b/libs/models/schema/ui/banners/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/models/schema/ui/banners/tsconfig.json
+++ b/libs/models/schema/ui/banners/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/models/schema/ui/banners/tsconfig.lib.json
+++ b/libs/models/schema/ui/banners/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/models/schema/ui/banners/tsconfig.spec.json
+++ b/libs/models/schema/ui/banners/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@elewa-website/data/ui/content-text": [
         "libs/data/ui/content-text/src/index.ts"
       ],
+      "@elewa-website/elements/banners": ["libs/elements/banners/src/index.ts"],
       "@elewa-website/elements/cards": ["libs/elements/cards/src/index.ts"],
       "@elewa-website/elements/layout/buttons": [
         "libs/elements/layout/buttons/src/index.ts"
@@ -65,24 +66,24 @@
       "@elewa-website/features/pages/home": [
         "libs/features/pages/home/src/index.ts"
       ],
-      "@elewa-website/libs/models/schema/ui/images": [
-        "libs/libs/models/schema/ui/images/src/index.ts"
-      ],
       "@elewa-website/features/pages/news-page": [
         "libs/features/pages/news-page/src/index.ts"
+      ],
+      "@elewa-website/libs/models/schema/ui/images": [
+        "libs/libs/models/schema/ui/images/src/index.ts"
       ],
       "@elewa-website/models/data/sections": [
         "libs/models/data/sections/src/index.ts"
       ],
       "@elewa-website/models/data/ui": ["libs/models/data/ui/src/index.ts"],
-      "@elewa-website/models/schema/ui/images": [
-        "libs/models/schema/ui/images/src/index.ts"
-      ],
       "@elewa-website/models/schema/ui/buttons": [
         "libs/models/schema/ui/buttons/src/index.ts"
       ],
       "@elewa-website/models/schema/ui/cards": [
         "libs/models/schema/ui/cards/src/index.ts"
+      ],
+      "@elewa-website/models/schema/ui/images": [
+        "libs/models/schema/ui/images/src/index.ts"
       ],
       "@elewa-website/models/schema/ui/texts": [
         "libs/models/schema/ui/texts/src/index.ts"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -76,6 +76,9 @@
         "libs/models/data/sections/src/index.ts"
       ],
       "@elewa-website/models/data/ui": ["libs/models/data/ui/src/index.ts"],
+      "@elewa-website/models/schema/ui/banners": [
+        "libs/models/schema/ui/banners/src/index.ts"
+      ],
       "@elewa-website/models/schema/ui/buttons": [
         "libs/models/schema/ui/buttons/src/index.ts"
       ],


### PR DESCRIPTION
# Description

created a re-usable image and text banner that receives an input of ImageAndText where position of image is passed that is ussed to detremine where image will be and text adapts since they are only two items.

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #8

## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)

## Screenshot (optional)

![Screenshot from 2023-09-04 15-00-30](https://github.com/italanta/elewa-website/assets/71401172/ecd19ffb-e392-470f-a5c3-496315a540b8)
![Screenshot from 2023-09-04 14-58-13](https://github.com/italanta/elewa-website/assets/71401172/9ebeb649-2c14-4f46-abeb-e5e72f2649b8)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
