### PR TITLE
🎨 Create Reusable Pricing List Component #141

### DIFF
--- a/apps/elewa-website/src/environments/environment.prod.ts.example
+++ b/apps/elewa-website/src/environments/environment.prod.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: true,
-};

--- a/apps/elewa-website/src/environments/environment.ts.example
+++ b/apps/elewa-website/src/environments/environment.ts.example
@@ -1,4 +1,0 @@
-export const environment = {
-  baseUrl: 'http://localhost:4200',
-  production: false,
-};

--- a/libs/data/sections/src/index.ts
+++ b/libs/data/sections/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/highlighted-news.data';
 export * from './lib/content-development-hero-section.data'
 export * from './lib/highlighted-sdg-list.data';
 export * from './lib/team-members-list.data'
+export * from './lib/pricing-list.data'

--- a/libs/data/sections/src/lib/pricing-list.data.ts
+++ b/libs/data/sections/src/lib/pricing-list.data.ts
@@ -1,0 +1,32 @@
+import { PriceItem } from "@elewa-website/models/schema/ui/cards";
+
+export const __highlightedPricingList: PriceItem[] = [
+    {
+        title: 'Elewa model',
+        amount: 1500,
+        subTitle: 'Lorem ipsum',
+        description: 'Lorem ipsum dolor sit amet. Ut sunt minus qui recusandae possimus est alias dolorum sit rerum harum non rerum assumenda At dolore cupiditate.',
+        sliderButton: {
+            text: 'Choose Plan',
+          },
+          amountColor: '#000000', 
+          textColor: '#000000',  
+          backgroundColor: '#F4EDFD' 
+        },{
+        title: 'Gold',
+          amount:1500, 
+          subTitle: 'Exclusive Features',
+          description: 'Lorem ipsum dolor sit amet. Ut sunt minus qui recusandae possimus est alias dolorum sit rerum harum non rerum assumenda At dolore cupiditate.',
+          sliderButton: {
+            text: 'Choose Plan',
+            bgColor:'white',
+            color:'black',
+            hoverBgColor:"black",
+            hoverColor:'white',     
+
+          },
+          amountColor: '#FFFFFF',
+          textColor: '#FFFFFF',  
+          backgroundColor: '#292A50' 
+        }
+]

--- a/libs/elements/cards/src/lib/cards.module.ts
+++ b/libs/elements/cards/src/lib/cards.module.ts
@@ -10,6 +10,7 @@ import { ElewaWebsitePriceItemCardComponent } from './components/elewa-price-ite
 import { ElewaTeamMemberCardComponent } from './components/elewa-team-member-card/team-member-card.component';
 import { ElewaSdgListComponent } from './components/elewa-sdg-list/elewa-sdg-list.component';
 import { ElewaSdgCardComponent } from './components/elewa-sdg-card/elewa-sdg-card.component';
+import { ElewaPriceListComponent } from './components/elewa-price-list/elewa-price-list.component';
 
 @NgModule({
   imports: [CommonModule, ButtonsModule],
@@ -21,6 +22,7 @@ import { ElewaSdgCardComponent } from './components/elewa-sdg-card/elewa-sdg-car
     ElewaTeamMemberCardComponent,
     ElewaSdgListComponent,
     ElewaSdgCardComponent,
+    ElewaPriceListComponent,
   ],
   exports: [
     ElewaInfoCardComponent,
@@ -29,7 +31,8 @@ import { ElewaSdgCardComponent } from './components/elewa-sdg-card/elewa-sdg-car
     ElewaProjectItemCardComponent,
     ElewaTeamMemberCardComponent,
     ElewaSdgListComponent,
-    ElewaSdgCardComponent
+    ElewaSdgCardComponent,
+    ElewaPriceListComponent
   ],
 })
 export class CardsModule {}

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.html
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.html
@@ -1,0 +1,1 @@
+<p>elewa-price-list works!</p>

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.html
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.html
@@ -1,1 +1,7 @@
-<p>elewa-price-list works!</p>
+<div class="outer-list">
+    <ul class="price-list" *ngFor="let item of priceitem">
+        <li class="price-cards">
+            <elewa-website-price-item-card [priceItem]="item"></elewa-website-price-item-card>
+        </li>
+    </ul>
+</div>

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.scss
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.scss
@@ -1,0 +1,20 @@
+.outer-list{
+    display: flex;
+    // justify-content: space-between;
+    align-items: center;
+    background-color: var(--elewa-website-news-section-bg-color);
+    width: 100%;
+    padding: 30px;
+
+}
+
+.price-list{
+   list-style: none;
+
+
+}
+
+.price-cards{
+    width: 350px;
+
+}

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.spec.ts
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaPriceListComponent } from './elewa-price-list.component';
+
+describe('ElewaPriceListComponent', () => {
+  let component: ElewaPriceListComponent;
+  let fixture: ComponentFixture<ElewaPriceListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaPriceListComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaPriceListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.ts
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-price-list',
+  templateUrl: './elewa-price-list.component.html',
+  styleUrls: ['./elewa-price-list.component.scss'],
+})
+export class ElewaPriceListComponent {}

--- a/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.ts
+++ b/libs/elements/cards/src/lib/components/elewa-price-list/elewa-price-list.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Input  } from '@angular/core';
+import { PriceItem } from '@elewa-website/models/schema/ui/cards';
+import { __highlightedPricingList } from '@elewa-website/data/sections';
 
 @Component({
   selector: 'elewa-website-elewa-price-list',
   templateUrl: './elewa-price-list.component.html',
   styleUrls: ['./elewa-price-list.component.scss'],
 })
-export class ElewaPriceListComponent {}
+export class ElewaPriceListComponent {
+  @Input() priceitem: PriceItem[]= __highlightedPricingList;
+}


### PR DESCRIPTION
# Description
Created elewa-price-list component <elewa-website-price-item-card [priceItem]="item">, this component can be reused anywhere in the site.

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #141 - Create Reusable Pricing List Component 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Screenshot (optional)
![Screenshot from 2023-09-01 15-02-03](https://github.com/italanta/elewa-website/assets/79338912/0dd54683-59a3-444d-86bf-c246f2fb3739)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

