### PR TITLE
✨ Consultancy page about section second#180

### DIFF
--- a/libs/data/sections/src/index.ts
+++ b/libs/data/sections/src/index.ts
@@ -10,3 +10,5 @@ export * from './lib/team-members-list.data';
 export * from './lib/team-members-list.data';
 export * from './lib/consultancy-hero.data';
 export * from './lib/content-dev-about.data';
+export * from './lib/consultancy-about-two.data';
+

--- a/libs/data/sections/src/lib/consultancy-about-two.data.ts
+++ b/libs/data/sections/src/lib/consultancy-about-two.data.ts
@@ -1,0 +1,31 @@
+import { ImageAndText } from '@elewa-website/models/schema/ui/image-and-text';
+import { ImageVisualisation } from '@elewa-website/models/schema/ui/images';
+
+export const __highlightedImageData: ImageAndText[] = [
+  {
+    content: {
+      title: 'First-line training',
+      descriptions: [
+        'Our core expertise lies in training of first-line workers. We identify the “first line” as any group of professionals that are geographically spread and that interface directly with clients or organisation infrastructure.',
+        'Through a smart mix of digital and human training modalities, we are able to up-skill in the first line in an impactful, continuous and affordable manner.',
+      ], 
+    },
+    image: {
+      imageSrc: 'https://www.securitymagazine.com/ext/resources/Default-images/Responsive-Defaults/keyboard.jpg?1566398203',
+      title: 'Image 2',
+      maxWidth: '500',
+      visualisation: ImageVisualisation.Pill,
+    },
+    imagePosition: 'right',
+  },
+
+  
+];
+
+export function getLayoutClass(item: ImageAndText): string {
+  
+  if (item && item.imagePosition) {
+    return item.imagePosition === 'right' ? 'right-image' : 'left-image';
+  }
+  return 'default-layout';
+}

--- a/libs/data/sections/src/lib/consultancy-about-two.data.ts
+++ b/libs/data/sections/src/lib/consultancy-about-two.data.ts
@@ -21,11 +21,3 @@ export const __highlightedImageData: ImageAndText[] = [
 
   
 ];
-
-export function getLayoutClass(item: ImageAndText): string {
-  
-  if (item && item.imagePosition) {
-    return item.imagePosition === 'right' ? 'right-image' : 'left-image';
-  }
-  return 'default-layout';
-}

--- a/libs/data/sections/src/lib/consultancy-about-two.data.ts
+++ b/libs/data/sections/src/lib/consultancy-about-two.data.ts
@@ -13,7 +13,7 @@ export const __highlightedImageData: ImageAndText[] = [
     image: {
       imageSrc: 'https://www.securitymagazine.com/ext/resources/Default-images/Responsive-Defaults/keyboard.jpg?1566398203',
       title: 'Image 2',
-      maxWidth: '500',
+      maxWidth: '600',
       visualisation: ImageVisualisation.Pill,
     },
     imagePosition: 'right',

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
@@ -1,0 +1,1 @@
+<p>elewa-consultancy-about-two works!</p>

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
@@ -1,1 +1,9 @@
-<p>elewa-consultancy-about-two works!</p>
+<div
+  *ngFor="let content of imageContent"
+  class="content-banner"
+  [ngClass]="getLayoutClass(content)"
+>
+  <elewa-website-image-and-text-banner
+    [ImageAndText]="content"
+  ></elewa-website-image-and-text-banner>
+</div>

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.html
@@ -1,7 +1,6 @@
 <div
   *ngFor="let content of imageContent"
   class="content-banner"
-  [ngClass]="getLayoutClass(content)"
 >
   <elewa-website-image-and-text-banner
     [ImageAndText]="content"

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.scss
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.scss
@@ -1,0 +1,14 @@
+.content-banner{
+    align-items: center;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    background: var(--elewa-consultancy-about-one-background-color); 
+}
+
+@media (max-width: 768px) {
+    .image-text-banner {
+      flex-direction: column; 
+      align-items: center; 
+    }
+  }

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.scss
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.scss
@@ -7,7 +7,7 @@
 }
 
 @media (max-width: 768px) {
-    .image-text-banner {
+    .content-banner {
       flex-direction: column; 
       align-items: center; 
     }

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.spec.ts
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ElewaConsultancyAboutTwoComponent } from './elewa-consultancy-about-two.component';
+
+describe('ElewaConsultancyAboutTwoComponent', () => {
+  let component: ElewaConsultancyAboutTwoComponent;
+  let fixture: ComponentFixture<ElewaConsultancyAboutTwoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ElewaConsultancyAboutTwoComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ElewaConsultancyAboutTwoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
@@ -1,8 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnInit} from '@angular/core';
+
+import { ImageAndText } from '@elewa-website/models/schema/ui/image-and-text';
+import { __highlightedImageData as highlightedImageData, getLayoutClass } from '@elewa-website/data/sections';
+
 
 @Component({
   selector: 'elewa-website-elewa-consultancy-about-two',
   templateUrl: './elewa-consultancy-about-two.component.html',
   styleUrls: ['./elewa-consultancy-about-two.component.scss'],
 })
-export class ElewaConsultancyAboutTwoComponent {}
+export class ElewaConsultancyAboutTwoComponent implements OnInit {
+  @Input() imageData !: ImageAndText[];
+  
+  ngOnInit(){
+    this.imageData = highlightedImageData;
+  }
+
+  getLayoutClass(item: ImageAndText): string {
+    return getLayoutClass(item);
+  }
+}

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
@@ -3,20 +3,19 @@ import { Component, Input, OnInit} from '@angular/core';
 import { ImageAndText } from '@elewa-website/models/schema/ui/image-and-text';
 import { __highlightedImageData as highlightedImageData, getLayoutClass } from '@elewa-website/data/sections';
 
-
 @Component({
   selector: 'elewa-website-elewa-consultancy-about-two',
   templateUrl: './elewa-consultancy-about-two.component.html',
   styleUrls: ['./elewa-consultancy-about-two.component.scss'],
 })
 export class ElewaConsultancyAboutTwoComponent implements OnInit {
-  @Input() imageData !: ImageAndText[];
+  @Input() imageContent !: ImageAndText[];
   
   ngOnInit(){
-    this.imageData = highlightedImageData;
+    this.imageContent = highlightedImageData;
   }
 
-  getLayoutClass(item: ImageAndText): string {
-    return getLayoutClass(item);
+  getLayoutClass(content: ImageAndText): string {
+    return getLayoutClass(content);
   }
 }

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit} from '@angular/core';
 
 import { ImageAndText } from '@elewa-website/models/schema/ui/image-and-text';
-import { __highlightedImageData as highlightedImageData, getLayoutClass } from '@elewa-website/data/sections';
+import { __highlightedImageData as highlightedImageData } from '@elewa-website/data/sections';
 
 @Component({
   selector: 'elewa-website-elewa-consultancy-about-two',
@@ -15,7 +15,6 @@ export class ElewaConsultancyAboutTwoComponent implements OnInit {
     this.imageContent = highlightedImageData;
   }
 
-  getLayoutClass(content: ImageAndText): string {
-    return getLayoutClass(content);
+ 
   }
-}
+

--- a/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
+++ b/libs/features/pages/consultancy-page/src/lib/components/elewa-consultancy-about-two/elewa-consultancy-about-two.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'elewa-website-elewa-consultancy-about-two',
+  templateUrl: './elewa-consultancy-about-two.component.html',
+  styleUrls: ['./elewa-consultancy-about-two.component.scss'],
+})
+export class ElewaConsultancyAboutTwoComponent {}

--- a/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
+++ b/libs/features/pages/consultancy-page/src/lib/consultancy-page.module.ts
@@ -11,6 +11,7 @@ import { ConsultancyHeroSectionComponent } from './components/consultancy-hero-s
 import { ConsultancyAboutOneComponent } from './components/consultancy-about-one/consultancy-about-one.component';
 
 import { ConsultancyRoutingModule } from './consultancy.routing';
+import { ElewaConsultancyAboutTwoComponent } from './components/elewa-consultancy-about-two/elewa-consultancy-about-two.component';
 
 @NgModule({
   imports: [
@@ -25,6 +26,7 @@ import { ConsultancyRoutingModule } from './consultancy.routing';
     ConsultancyPageComponent,
     ConsultancyHeroSectionComponent,
     ConsultancyAboutOneComponent,
+    ElewaConsultancyAboutTwoComponent,
   ],
   exports: [ConsultancyPageComponent],
 })

--- a/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
@@ -1,2 +1,3 @@
-<elewa-website-consultancy-hero-section></elewa-website-consultancy-hero-section>
-<elewa-website-consultancy-about-one [imageData]="content"></elewa-website-consultancy-about-one>
+<!-- <elewa-website-consultancy-hero-section></elewa-website-consultancy-hero-section>
+<elewa-website-consultancy-about-one [imageData]="content"></elewa-website-consultancy-about-one> -->
+<elewa-website-elewa-consultancy-about-two [imageContent]="content"> </elewa-website-elewa-consultancy-about-two>

--- a/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
+++ b/libs/features/pages/consultancy-page/src/lib/main/consultancy-page/consultancy-page.component.html
@@ -1,3 +1,3 @@
-<!-- <elewa-website-consultancy-hero-section></elewa-website-consultancy-hero-section>
-<elewa-website-consultancy-about-one [imageData]="content"></elewa-website-consultancy-about-one> -->
+<elewa-website-consultancy-hero-section></elewa-website-consultancy-hero-section>
+<elewa-website-consultancy-about-one [imageData]="content"></elewa-website-consultancy-about-one>
 <elewa-website-elewa-consultancy-about-two [imageContent]="content"> </elewa-website-elewa-consultancy-about-two>


### PR DESCRIPTION
# Description

This pull request contains a component that displays the second section of the about section on the consultancy page. It is responsive to both mobile and desktop

Fixes #180 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Screenshot 
![Screenshot from 2023-09-11 15-38-52](https://github.com/italanta/elewa-website/assets/106909700/064afe02-0e0a-4c0b-8e88-31e8abb36497)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
